### PR TITLE
fix redis endpoint in client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     environment:
       LOCAL: "true"
       ENV_NAME: test
-      REDIS_ENDPOINT: redis://redis:6379
+      REDIS_ENDPOINT: redis
       DYNAMODB_ENDPOINT: http://dynamodb-local:8000
       USER_TABLE: test_Users
       MESSAGE_TABLE: test_Messages


### PR DESCRIPTION
That redis url is not working. I change it for `redis` that is the name of the service and it works in my local.